### PR TITLE
Make auto reconnection handle ws4py exceptions as well as socket excepti...

### DIFF
--- a/DDPClient.py
+++ b/DDPClient.py
@@ -3,6 +3,7 @@ import json
 import time
 import socket
 
+from ws4py.exc import WebSocketException
 from ws4py.client.threadedclient import WebSocketClient
 from pyee import EventEmitter
 
@@ -86,7 +87,7 @@ class DDPClient(EventEmitter):
                     connected = True
                     self.ddpsocket._debug_log("* RECONNECTED")
                     self.emit('reconnected')
-                except socket.error:
+                except (socket.error, WebSocketException):
                     pass
 
     def _next_id(self):


### PR DESCRIPTION
hi again!

while doing development on the meteor end of my project i noticed that if meteor restarted too quickly then `recover_network_failure` often receives ws4py exceptions such as `HandshakeError` and so stops trying to reconnect.

this patch just makes it catch ws4py exceptions as well as the already caught socket errors so that reconnection keeps trying.
