### PR TITLE
fix checking for existence of socket in DDPSocket

### DIFF
--- a/DDPClient.py
+++ b/DDPClient.py
@@ -43,30 +43,11 @@ class DDPSocket(WebSocketClient, EventEmitter):
         sys.stderr.write('{}\n'.format(msg))
 
     def once(self):
-        """ OVERRIDE FROM WebSocket
-        Performs the operation of reading from the underlying
-        connection in order to feed the stream of bytes.
-        We start with a small size of two bytes to be read
-        from the connection so that we can quickly parse an
-        incoming frame header. Then the stream indicates
-        whatever size must be read from the connection since
-        it knows the frame payload length.
-        It returns `False` if an error occurred at the
-        socket level or during the bytes processing. Otherwise,
-        it returns `True`."""
         # check for self.sock existence
         # https://github.com/hharnisc/python-meteor/issues/5
-        if self.terminated or not self.sock:
-            return False
-
-        try:
-            b = self.sock.recv(self.reading_buffer_size)
-        except socket.error:
-            return False
-        else:
-            if not self.process(b):
-                return False
-
+        if self.sock:
+            return super(DDPSocket, self).once()
+        return False
 
 
 class DDPClient(EventEmitter):


### PR DESCRIPTION
5998839 broke things by not returning True when the processing
of incoming data succeeded.

This commit calls the overidden method using super instead of
copying and pasting.

i think this might also fix issues hharnisc/python-meteor#10 and hharnisc/python-meteor#11