### PR TITLE
Support DDP version 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 DDPCommandLineTool.py
 python_ddp.egg-info
 *~
+*.pyc
+build

--- a/DDPClient.py
+++ b/DDPClient.py
@@ -7,7 +7,7 @@ from ws4py.exc import WebSocketException
 from ws4py.client.threadedclient import WebSocketClient
 from pyee import EventEmitter
 
-DDP_VERSIONS = ["pre1"]
+DDP_VERSIONS = ["1"]
 
 class DDPSocket(WebSocketClient, EventEmitter):
     """DDPSocket"""
@@ -190,6 +190,14 @@ class DDPClient(EventEmitter):
                 if callback:
                     callback(data.get('error'), sub_id)
                     self._callbacks.pop(sub_id)
+
+        elif data['msg'] == 'ping':
+            msg = {'msg': 'pong'}
+            id = data.get('id')
+            if id is not None:
+                msg['id'] = id
+            self.ddpsocket.send(msg)
+
         else:
             pass
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,23 @@ client.on('failed', failed)
 
 _data_ - the error data  
 
+#### version_mismatch
+
+Register the event to a callback function
+
+This event is fired if the server and client can not agree on a DDP version to use and is a fatal error
+
+```python
+def version_mismatch(versions):
+    print '* VERSION MISMATCH - versions: {}'.format(str(versions))
+
+client.on('version_mismatch', version_mismatch)
+```
+
+`version_mismatch` callback takes the following arguments
+
+_versions_ - the DDP versions attempted
+
 #### added
 
 Register the event to a callback function
@@ -279,6 +296,7 @@ client.on('connected', connected)
 client.on('socket_closed', closed)
 client.on('reconnected', reconnected)
 client.on('failed', failed)
+client.on('version_mismatch', version_mismatch)
 client.on('added', added)
 client.on('changed', changed)
 client.on('removed', removed)


### PR DESCRIPTION
hi @hharnisc!

I did this because we needed `ping`/`pong` support as our app is deployed behind nginx and it was timing out the long running websocket connections at times when the devices we are using this with are not chatty enough (that'll teach us to make them more efficient!). I've done quite a lot of testing but haven't pushed this into production yet.

This adds support for versions `pre2` and `1` (which are basically the same) alongside the original pre1 DDP versions. The [DDP spec](https://github.com/meteor/meteor/blob/master/packages/ddp/DDP.md) is a little vague, but i think everything that needs to be implemented is included here (our app behaves ok anyway!). This means the only thing that is added is automatic responses to `ping` messages, as well as negotiating which version to use with the server when you connect.

I added a new event `version_mismatch` which is fired when the server and client can't agree on a DDP version to use, but looking at it now I'm thinking it should really raise an exception instead? Let me know what you think and I'll be happy to change it to an exception (or change any of the rest of it too!) if you think that is better.

i am also setting the socket timeout, because with [meteorhacks:cluster](https://github.com/meteorhacks/cluster) it was getting into a state where the socket reconnected if the server was restarted, but the server never sent any data. I guess that is actually a bug in cluster, but i don't really understand how that works yet :wink: 

thanks,

paul.
