### PR TITLE
use ejson instead of json to support datetime

### DIFF
--- a/DDPClient.py
+++ b/DDPClient.py
@@ -1,5 +1,5 @@
 import sys
-import json
+import ejson
 import time
 import socket
 
@@ -28,7 +28,7 @@ class DDPSocket(WebSocketClient, EventEmitter):
     def send(self, msg_dict):
         """Send a message through the websocket client and wait for the
         answer if the message being sent contains an id attribute."""
-        message = json.dumps(msg_dict)
+        message = ejson.dumps(msg_dict)
         super(DDPSocket, self).send(message)
         self._debug_log('<<<{}'.format(message))
 
@@ -137,7 +137,7 @@ class DDPClient(EventEmitter):
 
     def received_message(self, data):
         """Incomming messages"""
-        data = json.loads(str(data))
+        data = ejson.loads(str(data))
         if not data.get('msg'):
             return
 
@@ -212,7 +212,7 @@ class DDPClient(EventEmitter):
 
         Arguments:
         name - the name of the publication to subscribe
-        params - params to subscribe (parsed as json)
+        params - params to subscribe (parsed as ejson)
 
         Keyword Arguments:
         callback - a callback function that gets executed when the subscription has completed"""

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(name='python-ddp',
     py_modules=['DDPClient'],
     install_requires=[
         'pyee',
-        'ws4py'
+        'ws4py',
+        'meteor-ejson'
     ],
 )


### PR DESCRIPTION
I propose to use [meteor-ejson](https://pypi.python.org/pypi/meteor-ejson/1.0.0) instead of json to support datetimes. 